### PR TITLE
Added buffer auto-close functionality on swapfile event

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -106,6 +106,17 @@ following value to `0` in your `.vimrc`:
 let g:one#handleSwapfileConflicts = 1     " 0=disable, 1=enable (def)
 ```
 
+### Buffer auto-close on swapfile conflicts
+
+If swapfile is enabled and you request that a file be loaded that is
+already loaded on another server instance, _onevim_ will automatically
+close the local buffer opened by `:edit`. Requires
+`g:one#handleSwapfileConflicts` to be set.
+
+```
+let g:one#autocloseOpenedBuffers = 1      " 0=disable (def), 1=enable
+```
+
 ### Window placement on splits
 
 To control the placement of windows on splits, add to your `.vimrc`:

--- a/plugin/one.vim
+++ b/plugin/one.vim
@@ -18,9 +18,14 @@ if !exists('g:one#handleSwapfileConflicts')
   let g:one#handleSwapfileConflicts = 1     " 0=disable, 1=enable (def)
 endif
 
+if !exists('g:autocloseOpenedBuffers')
+  " by default, do not autoclose buffers
+  let g:one#autocloseOpenedBuffers = 0      " 0=disable (def), 1=enable
+endif
+
 " Execute handler whenever swapfile is detected
 if g:one#handleSwapfileConflicts &&
- \ has('autocmd') && 
+ \ has('autocmd') &&
  \ &swapfile
   augroup one_autoswap_detect
     autocmd!


### PR DESCRIPTION
Since I drive my environment with buffers/splits, I wanted to keep my buffer bar uncluttered. By default when a swap was open in a remote instance, the buffer bar tab would stay open and be inaccessible to edit or close. This adds a variable that, when enabled, will auto-close the local buffer who's swapfile was already opened by a remote instance. Sorry for the PR on a very old repo xD